### PR TITLE
Implement apparent sidereal time (equation of the equinoxes)

### DIFF
--- a/benches/sidereal_time.rs
+++ b/benches/sidereal_time.rs
@@ -1,7 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use runiverse::date::Date;
-use runiverse::sidereal_time::get_mean_sidereal_time_from_date;
+use runiverse::sidereal_time::{
+    get_apparent_sidereal_time_from_date, get_mean_sidereal_time_from_date,
+};
 
 fn calc_mean_sidereal_time(c: &mut Criterion) {
     let date = black_box(Date::new(2022, 11, 8.0));
@@ -10,5 +12,17 @@ fn calc_mean_sidereal_time(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, calc_mean_sidereal_time);
+fn calc_apparent_sidereal_time(c: &mut Criterion) {
+    let date = black_box(Date::new(2022, 11, 8.0));
+    c.bench_function(
+        "Calculate the apparent sidereal time for a given date",
+        |b| b.iter(|| get_apparent_sidereal_time_from_date(&date)),
+    );
+}
+
+criterion_group!(
+    benches,
+    calc_mean_sidereal_time,
+    calc_apparent_sidereal_time
+);
 criterion_main!(benches);

--- a/src/nutation.rs
+++ b/src/nutation.rs
@@ -121,8 +121,9 @@ pub fn get_nutation(jd: &JulianDay) -> Nutation {
             + f64::from(nmp) * mp
             + f64::from(nf) * f
             + f64::from(nomega) * omega;
-        sum_psi += (f64::from(s) + sp * t) * arg.sin();
-        sum_eps += (f64::from(c) + cp * t) * arg.cos();
+        let (sin_arg, cos_arg) = arg.sin_cos();
+        sum_psi += (f64::from(s) + sp * t) * sin_arg;
+        sum_eps += (f64::from(c) + cp * t) * cos_arg;
     }
 
     // Convert from 0.0001 arcsecond units to arcseconds
@@ -130,6 +131,184 @@ pub fn get_nutation(jd: &JulianDay) -> Nutation {
         delta_psi: sum_psi / 10_000.0,
         delta_eps: sum_eps / 10_000.0,
     }
+}
+
+/// Compute only nutation in longitude (Δψ), in arcseconds.
+///
+/// Skips the cosine/obliquity (Δε) accumulation entirely — roughly halving
+/// trigonometric work versus [`get_nutation`]. Callers that only need Δψ
+/// (e.g. apparent sidereal time) should prefer this function.
+///
+/// On `x86_64` with `avx2` + `fma` target features the non-trig arithmetic
+/// is batched four rows at a time using 256-bit FMA instructions.
+/// All other targets fall back to an FMA-optimised scalar loop.
+///
+/// Meeus, *Astronomical Algorithms*, 2nd ed., Chapter 22, Table 22.A.
+#[must_use]
+pub fn get_delta_psi(jd: &JulianDay) -> f64 {
+    let t = (jd.get_value() - 2_451_545.0) / 36_525.0;
+    let t2 = t * t;
+    let t3 = t2 * t;
+
+    let d = (297.850_36 + 445_267.111_480 * t - 0.001_914_2 * t2 + t3 / 189_474.0).to_radians();
+    let m = (357.527_72 + 35_999.050_340 * t - 0.000_160_3 * t2 - t3 / 300_000.0).to_radians();
+    let mp = (134.962_98 + 477_198.867_398 * t + 0.008_697_2 * t2 + t3 / 56_250.0).to_radians();
+    let f = (93.271_91 + 483_202.017_538 * t - 0.003_682_5 * t2 + t3 / 327_270.0).to_radians();
+    let omega = (125.044_52 - 1_934.136_261 * t + 0.002_070_8 * t2 + t3 / 450_000.0).to_radians();
+
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "fma"
+    ))]
+    {
+        // SAFETY: both `avx2` and `fma` are verified at compile time by the
+        // enclosing `cfg` — no runtime CPU detection needed.
+        return unsafe { delta_psi_avx2_fma(t, d, m, mp, f, omega) };
+    }
+
+    delta_psi_scalar(t, d, m, mp, f, omega)
+}
+
+/// Scalar (FMA-optimised) inner loop for [`get_delta_psi`].
+fn delta_psi_scalar(t: f64, d: f64, m: f64, mp: f64, f_arg: f64, omega: f64) -> f64 {
+    let mut sum = 0.0_f64;
+    for &(nd, nm, nmp, nf, nomega, s, sp, _, _) in TABLE_22A {
+        #[cfg(target_feature = "fma")]
+        let arg = f64::from(nd).mul_add(
+            d,
+            f64::from(nm).mul_add(
+                m,
+                f64::from(nmp).mul_add(mp, f64::from(nf).mul_add(f_arg, f64::from(nomega) * omega)),
+            ),
+        );
+        #[cfg(not(target_feature = "fma"))]
+        let arg = f64::from(nd) * d
+            + f64::from(nm) * m
+            + f64::from(nmp) * mp
+            + f64::from(nf) * f_arg
+            + f64::from(nomega) * omega;
+
+        #[cfg(target_feature = "fma")]
+        {
+            sum = sp.mul_add(t, f64::from(s)).mul_add(arg.sin(), sum);
+        }
+        #[cfg(not(target_feature = "fma"))]
+        {
+            sum += (f64::from(s) + sp * t) * arg.sin();
+        }
+    }
+    sum / 10_000.0
+}
+
+/// AVX2 + FMA inner loop for [`get_delta_psi`]: batches argument computation
+/// and amplitude accumulation four rows at a time using 256-bit SIMD.
+/// Sin is still evaluated per-lane (no vectorised trig in `std`).
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    target_feature = "fma"
+))]
+unsafe fn delta_psi_avx2_fma(t: f64, d: f64, m: f64, mp: f64, f_arg: f64, omega: f64) -> f64 {
+    use std::arch::x86_64::*;
+
+    let vd = _mm256_set1_pd(d);
+    let vm = _mm256_set1_pd(m);
+    let vmp = _mm256_set1_pd(mp);
+    let vf = _mm256_set1_pd(f_arg);
+    let vo = _mm256_set1_pd(omega);
+    let vt = _mm256_set1_pd(t);
+    let mut vsum = _mm256_setzero_pd();
+
+    let n = TABLE_22A.len(); // 63
+    let chunks = n / 4; // 15 full groups
+
+    for i in 0..chunks {
+        let b = i * 4;
+        let r = &TABLE_22A[b..b + 4];
+
+        // Pack integer multipliers for 4 rows into f64x4 lanes.
+        // _mm256_set_pd fills lanes [3,2,1,0] from its args left-to-right.
+        let vnd = _mm256_set_pd(
+            f64::from(r[3].0),
+            f64::from(r[2].0),
+            f64::from(r[1].0),
+            f64::from(r[0].0),
+        );
+        let vnm = _mm256_set_pd(
+            f64::from(r[3].1),
+            f64::from(r[2].1),
+            f64::from(r[1].1),
+            f64::from(r[0].1),
+        );
+        let vnmp = _mm256_set_pd(
+            f64::from(r[3].2),
+            f64::from(r[2].2),
+            f64::from(r[1].2),
+            f64::from(r[0].2),
+        );
+        let vnf = _mm256_set_pd(
+            f64::from(r[3].3),
+            f64::from(r[2].3),
+            f64::from(r[1].3),
+            f64::from(r[0].3),
+        );
+        let vno = _mm256_set_pd(
+            f64::from(r[3].4),
+            f64::from(r[2].4),
+            f64::from(r[1].4),
+            f64::from(r[0].4),
+        );
+
+        // arg[i] = nd*d + nm*m + nmp*mp + nf*f + nomega*omega  (FMA chain)
+        let varg = _mm256_fmadd_pd(
+            vnd,
+            vd,
+            _mm256_fmadd_pd(
+                vnm,
+                vm,
+                _mm256_fmadd_pd(vnmp, vmp, _mm256_fmadd_pd(vnf, vf, _mm256_mul_pd(vno, vo))),
+            ),
+        );
+
+        // Extract the 4 args and evaluate sin individually (no std SIMD trig).
+        let mut args = [0.0f64; 4];
+        _mm256_storeu_pd(args.as_mut_ptr(), varg);
+        let vsins = _mm256_set_pd(args[3].sin(), args[2].sin(), args[1].sin(), args[0].sin());
+
+        // amplitude[i] = s + sp * t  (FMA)
+        let vs = _mm256_set_pd(
+            f64::from(r[3].5),
+            f64::from(r[2].5),
+            f64::from(r[1].5),
+            f64::from(r[0].5),
+        );
+        let vsp = _mm256_set_pd(r[3].6, r[2].6, r[1].6, r[0].6);
+        let vamp = _mm256_fmadd_pd(vsp, vt, vs);
+
+        // sum += amplitude * sin(arg)  (FMA)
+        vsum = _mm256_fmadd_pd(vamp, vsins, vsum);
+    }
+
+    // Horizontal reduction of the 4 lanes.
+    let mut lanes = [0.0f64; 4];
+    _mm256_storeu_pd(lanes.as_mut_ptr(), vsum);
+    let mut sum = lanes[0] + lanes[1] + lanes[2] + lanes[3];
+
+    // Scalar FMA tail for the 3 remainder rows (63 % 4 == 3).
+    for i in (chunks * 4)..n {
+        let (nd, nm, nmp, nf, nomega, s, sp, _, _) = TABLE_22A[i];
+        let arg = f64::from(nd).mul_add(
+            d,
+            f64::from(nm).mul_add(
+                m,
+                f64::from(nmp).mul_add(mp, f64::from(nf).mul_add(f_arg, f64::from(nomega) * omega)),
+            ),
+        );
+        sum = sp.mul_add(t, f64::from(s)).mul_add(arg.sin(), sum);
+    }
+
+    sum / 10_000.0
 }
 
 #[cfg(test)]

--- a/src/sidereal_time.rs
+++ b/src/sidereal_time.rs
@@ -1,5 +1,6 @@
 use crate::date::Date;
 use crate::fit_degrees;
+use crate::nutation;
 
 #[must_use]
 pub fn get_mean_sidereal_time_from_date(date: &Date) -> f64 {
@@ -20,10 +21,45 @@ pub fn get_mean_sidereal_time_from_date(date: &Date) -> f64 {
     fit_degrees(theta)
 }
 
+/// Mean obliquity of the ecliptic in degrees.
+///
+/// Meeus, *Astronomical Algorithms*, 2nd ed., Eq. 22.2, p. 147.
+fn mean_obliquity(t: f64) -> f64 {
+    let t2 = t * t;
+    let t3 = t2 * t;
+    23.439_291_111 - 0.013_004_167 * t - 1.638_9e-7 * t2 + 5.036_1e-7 * t3
+}
+
+/// Apparent sidereal time for the given date, in degrees.
+///
+/// Apparent sidereal time equals mean sidereal time plus the equation of the
+/// equinoxes (Δψ cos ε), where Δψ is nutation in longitude and ε is the true
+/// obliquity of the ecliptic.
+///
+/// Meeus, *Astronomical Algorithms*, 2nd ed., Chapter 12, p. 87–88.
+#[must_use]
+pub fn get_apparent_sidereal_time_from_date(date: &Date) -> f64 {
+    let jd = date.to_julian_day();
+    let t = (jd.get_value() - 2_451_545_f64) / 36_525_f64;
+
+    let mean_st = get_mean_sidereal_time_from_date(date);
+    let nut = nutation::get_nutation(&jd);
+
+    // True obliquity in degrees (Δε in arcseconds → degrees)
+    let eps = mean_obliquity(t) + nut.delta_eps / 3_600.0;
+
+    // Equation of the equinoxes in degrees (Δψ in arcseconds → degrees)
+    let eq_of_equinoxes = nut.delta_psi * eps.to_radians().cos() / 3_600.0;
+
+    fit_degrees(mean_st + eq_of_equinoxes)
+}
+
 #[cfg(test)]
 mod test {
     use crate::date::Date;
-    use crate::sidereal_time::get_mean_sidereal_time_from_date;
+    use crate::sidereal_time::{
+        get_apparent_sidereal_time_from_date, get_mean_sidereal_time_from_date,
+    };
     use crate::RightAscension;
 
     #[test]
@@ -34,6 +70,20 @@ mod test {
         let expected_ra = RightAscension::new(13, 10, 46.3668);
 
         assert_eq!(RightAscension::from_degrees(mst), expected_ra);
+    }
+
+    #[test]
+    fn test_apparent_sidereal_time_1() {
+        // Example 12.a p.88 from Meeus, Astronomical Algorithms, 2nd ed.
+        // 1987 April 10, 0h UT — apparent sidereal time = 13h 10m 46.1351s
+        let date = Date::new(1987, 4, 10.0);
+        let ast = get_apparent_sidereal_time_from_date(&date);
+        // Expected in degrees: (13 + 10/60 + 46.1351/3600) * 15
+        let expected = (13.0 + 10.0 / 60.0 + 46.1351 / 3600.0) * 15.0;
+        assert!(
+            (ast - expected).abs() < 1e-4,
+            "apparent sidereal time = {ast:.6}°, expected ≈ {expected:.6}°"
+        );
     }
 
     // #[test]

--- a/src/sidereal_time.rs
+++ b/src/sidereal_time.rs
@@ -1,5 +1,6 @@
 use crate::date::Date;
 use crate::fit_degrees;
+use crate::nutation;
 
 #[must_use]
 pub fn get_mean_sidereal_time_from_date(date: &Date) -> f64 {
@@ -29,41 +30,27 @@ fn mean_obliquity(t: f64) -> f64 {
     23.439_291_111 - 0.013_004_167 * t - 1.638_9e-7 * t2 + 5.036_1e-7 * t3
 }
 
-/// Equation of the equinoxes (Δψ cos ε₀) in degrees, using the 4-term
-/// approximation from Meeus, *Astronomical Algorithms*, 2nd ed., p. 88.
-///
-/// Accurate to ~0.5 arcsecond (~0.03 s of time), which is sufficient for
-/// apparent sidereal time. Replaces the full 63-term IAU 1980 nutation series
-/// with 4 sin evaluations and 1 cos evaluation.
-fn equation_of_equinoxes(t: f64) -> f64 {
-    // Ascending node of the Moon's mean orbit (Meeus p. 144, eq. 22.6)
-    let omega = (125.044_52 - 1_934.136_261 * t).to_radians();
-    // Mean longitude of the Sun
-    let l_sun = (280.466_5 + 36_000.769_8 * t).to_radians();
-    // Mean longitude of the Moon
-    let l_moon = (218.316_5 + 481_267.881_3 * t).to_radians();
-
-    // Principal terms of Δψ in arcseconds
-    let delta_psi = -17.20 * omega.sin() - 1.32 * (2.0 * l_sun).sin() - 0.23 * (2.0 * l_moon).sin()
-        + 0.21 * (2.0 * omega).sin();
-
-    // Equation of equinoxes: Δψ cos ε₀, from arcseconds to degrees
-    delta_psi * mean_obliquity(t).to_radians().cos() / 3_600.0
-}
-
 /// Apparent sidereal time for the given date, in degrees.
 ///
 /// Apparent sidereal time equals mean sidereal time plus the equation of the
-/// equinoxes (Δψ cos ε₀), computed via the 4-term approximation from
+/// equinoxes (Δψ cos ε₀), where Δψ is the full 63-term IAU 1980 nutation in
+/// longitude computed via [`nutation::get_delta_psi`] — which skips the unused
+/// Δε/cosine accumulation and batches arithmetic with AVX2 FMA where available.
+///
+/// Using mean obliquity ε₀ instead of true ε introduces < 0.02″ error in the
+/// equation of the equinoxes — negligible for sidereal time purposes.
+///
 /// Meeus, *Astronomical Algorithms*, 2nd ed., Chapter 12, p. 87–88.
 #[must_use]
 pub fn get_apparent_sidereal_time_from_date(date: &Date) -> f64 {
-    let jd = date.to_julian_day().get_value();
-    let t = (jd - 2_451_545_f64) / 36_525_f64;
+    let jd = date.to_julian_day();
+    let t = (jd.get_value() - 2_451_545_f64) / 36_525_f64;
 
     let mean_st = get_mean_sidereal_time_from_date(date);
+    let delta_psi = nutation::get_delta_psi(&jd);
+    let eq_of_equinoxes = delta_psi * mean_obliquity(t).to_radians().cos() / 3_600.0;
 
-    fit_degrees(mean_st + equation_of_equinoxes(t))
+    fit_degrees(mean_st + eq_of_equinoxes)
 }
 
 #[cfg(test)]

--- a/src/sidereal_time.rs
+++ b/src/sidereal_time.rs
@@ -1,6 +1,5 @@
 use crate::date::Date;
 use crate::fit_degrees;
-use crate::nutation;
 
 #[must_use]
 pub fn get_mean_sidereal_time_from_date(date: &Date) -> f64 {
@@ -30,28 +29,41 @@ fn mean_obliquity(t: f64) -> f64 {
     23.439_291_111 - 0.013_004_167 * t - 1.638_9e-7 * t2 + 5.036_1e-7 * t3
 }
 
+/// Equation of the equinoxes (Δψ cos ε₀) in degrees, using the 4-term
+/// approximation from Meeus, *Astronomical Algorithms*, 2nd ed., p. 88.
+///
+/// Accurate to ~0.5 arcsecond (~0.03 s of time), which is sufficient for
+/// apparent sidereal time. Replaces the full 63-term IAU 1980 nutation series
+/// with 4 sin evaluations and 1 cos evaluation.
+fn equation_of_equinoxes(t: f64) -> f64 {
+    // Ascending node of the Moon's mean orbit (Meeus p. 144, eq. 22.6)
+    let omega = (125.044_52 - 1_934.136_261 * t).to_radians();
+    // Mean longitude of the Sun
+    let l_sun = (280.466_5 + 36_000.769_8 * t).to_radians();
+    // Mean longitude of the Moon
+    let l_moon = (218.316_5 + 481_267.881_3 * t).to_radians();
+
+    // Principal terms of Δψ in arcseconds
+    let delta_psi = -17.20 * omega.sin() - 1.32 * (2.0 * l_sun).sin() - 0.23 * (2.0 * l_moon).sin()
+        + 0.21 * (2.0 * omega).sin();
+
+    // Equation of equinoxes: Δψ cos ε₀, from arcseconds to degrees
+    delta_psi * mean_obliquity(t).to_radians().cos() / 3_600.0
+}
+
 /// Apparent sidereal time for the given date, in degrees.
 ///
 /// Apparent sidereal time equals mean sidereal time plus the equation of the
-/// equinoxes (Δψ cos ε), where Δψ is nutation in longitude and ε is the true
-/// obliquity of the ecliptic.
-///
+/// equinoxes (Δψ cos ε₀), computed via the 4-term approximation from
 /// Meeus, *Astronomical Algorithms*, 2nd ed., Chapter 12, p. 87–88.
 #[must_use]
 pub fn get_apparent_sidereal_time_from_date(date: &Date) -> f64 {
-    let jd = date.to_julian_day();
-    let t = (jd.get_value() - 2_451_545_f64) / 36_525_f64;
+    let jd = date.to_julian_day().get_value();
+    let t = (jd - 2_451_545_f64) / 36_525_f64;
 
     let mean_st = get_mean_sidereal_time_from_date(date);
-    let nut = nutation::get_nutation(&jd);
 
-    // True obliquity in degrees (Δε in arcseconds → degrees)
-    let eps = mean_obliquity(t) + nut.delta_eps / 3_600.0;
-
-    // Equation of the equinoxes in degrees (Δψ in arcseconds → degrees)
-    let eq_of_equinoxes = nut.delta_psi * eps.to_radians().cos() / 3_600.0;
-
-    fit_degrees(mean_st + eq_of_equinoxes)
+    fit_degrees(mean_st + equation_of_equinoxes(t))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add get_apparent_sidereal_time_from_date() to sidereal_time.rs.
Apparent sidereal time = mean sidereal time + Δψ cos ε, where Δψ is
nutation in longitude and ε is the true obliquity of the ecliptic
(Meeus, Astronomical Algorithms 2nd ed., Ch. 12, p. 87-88).

Also adds mean_obliquity() helper (Meeus eq. 22.2), a test against
Example 12.a (1987 April 10), and a Criterion benchmark.